### PR TITLE
Allow updating SubscriptionLineItem by ID.

### DIFF
--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -215,8 +215,22 @@ defmodule Stripe.Request do
     params =
       Enum.reduce(to_cast, params, fn key, params ->
         case params[key] do
-          %{__struct__: _, id: id} -> put_in(params[key], id)
-          _ -> params
+          %{__struct__: _, id: id} ->
+            put_in(params[key], id)
+
+          list when is_list(list) ->
+            new_list =
+              Enum.map(list, fn %{id: id} = list_item ->
+                case id do
+                  %{__struct__: _, id: id} -> put_in(list_item.id, id)
+                  _ -> list_item
+                end
+              end)
+
+            put_in(params[key], new_list)
+
+          _ ->
+            params
         end
       end)
 

--- a/lib/stripe/subscriptions/subscription.ex
+++ b/lib/stripe/subscriptions/subscription.ex
@@ -155,6 +155,7 @@ defmodule Stripe.Subscription do
                optional(:items) => [
                  %{
                    :plan => Stripe.id() | Stripe.Plan.t(),
+                   optional(:id) => Stripe.id() | Stripe.SubscriptionItem.t(),
                    optional(:quantity) => non_neg_integer
                  }
                ],
@@ -170,7 +171,7 @@ defmodule Stripe.Subscription do
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
     |> put_method(:post)
     |> put_params(params)
-    |> cast_to_id([:coupon])
+    |> cast_to_id([:coupon, :items])
     |> make_request()
   end
 

--- a/test/stripe/subscriptions/subscription_test.exs
+++ b/test/stripe/subscriptions/subscription_test.exs
@@ -47,7 +47,11 @@ defmodule Stripe.SubscriptionTest do
 
   describe "update/2" do
     test "updates a subscription" do
-      params = %{metadata: %{foo: "bar"}}
+      params = %{
+        metadata: %{foo: "bar"},
+        items: [%{id: 1}, %{id: %Stripe.SubscriptionItem{id: 2}}]
+      }
+
       assert {:ok, subscription} = Stripe.Subscription.update("sub_123", params)
       assert_stripe_requested(:post, "/v1/subscriptions/#{subscription.id}")
     end


### PR DESCRIPTION
It is possible to update Subscription's single subscription item when updating Subscription:
https://stripe.com/docs/api/subscriptions/update#update_subscription-items-id

So i thought it would be nice to allow this in the lib.

Currently, it is possible to update this way, but @spec is different and we end up having dialyzer warning about not matched parameters.