### PR TITLE
stripity-stripe => stripe-elixir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-stripity_stripe-*.tar
+stripe_elixir-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 An Elixir library for working with [Stripe](https://stripe.com/).
 
-[![Hex.pm](https://img.shields.io/hexpm/v/stripity_stripe.svg?maxAge=2592000)](https://hex.pm/packages/stripity_stripe) [![Hex.pm](https://img.shields.io/hexpm/dt/stripity_stripe.svg?maxAge=2592000)](https://hex.pm/packages/stripity_stripe)
+[![Hex.pm](https://img.shields.io/hexpm/v/stripe_elixir.svg?maxAge=2592000)](https://hex.pm/packages/stripe_elixir) [![Hex.pm](https://img.shields.io/hexpm/dt/stripe_elixir.svg?maxAge=2592000)](https://hex.pm/packages/stripe_elixir)
 
 ## 2.x.x status
 
-[![Build Status](https://travis-ci.org/code-corps/stripity_stripe.svg?branch=master)](https://travis-ci.org/code-corps/stripity_stripe) [![Hex Docs](https://img.shields.io/badge/hex-docs-9768d1.svg)](https://hexdocs.pm/stripity_stripe) [![Inline docs](http://inch-ci.org/github/code-corps/stripity_stripe.svg?branch=master)](http://inch-ci.org/github/code-corps/stripity_stripe?branch=master) [![Coverage Status](https://coveralls.io/repos/github/code-corps/stripity_stripe/badge.svg?branch=master)](https://coveralls.io/github/code-corps/stripity_stripe?branch=master)
+[![Build Status](https://travis-ci.org/beam-community/stripe-elixir.svg?branch=master)](https://travis-ci.org/beam-community/stripe-elixir) [![Hex Docs](https://img.shields.io/badge/hex-docs-9768d1.svg)](https://hexdocs.pm/stripe_elixir) [![Inline docs](http://inch-ci.org/github/beam-community/stripe-elixir.svg?branch=master)](http://inch-ci.org/github/beam-community/stripe-elixir?branch=master) [![Coverage Status](https://coveralls.io/repos/github/beam-community/stripe-elixir/badge.svg?branch=master)](https://coveralls.io/github/beam-community/stripe-elixir?branch=master)
 
 ## 1.x.x status
 
-[![Build Status](https://travis-ci.org/code-corps/stripity_stripe.svg?branch=1.x.x)](https://travis-ci.org/code-corps/stripity_stripe) [![Hex Docs](https://img.shields.io/badge/hex-docs-9768d1.svg)](https://hexdocs.pm/stripity_stripe/1.6.2) [![Inline docs](http://inch-ci.org/github/code-corps/stripity_stripe.svg?branch=1.x.x)](http://inch-ci.org/github/code-corps/stripity_stripe?branch=1.x.x) [![Coverage Status](https://coveralls.io/repos/github/code-corps/stripity_stripe/badge.svg?branch=1.x.x)](https://coveralls.io/github/code-corps/stripity_stripe?branch=1.x.x)
+[![Build Status](https://travis-ci.org/beam-community/stripe-elixir.svg?branch=1.x.x)](https://travis-ci.org/beam-community/stripe-elixir) [![Hex Docs](https://img.shields.io/badge/hex-docs-9768d1.svg)](https://hexdocs.pm/stripe_elixir/1.6.2) [![Inline docs](http://inch-ci.org/github/beam-community/stripe-elixir.svg?branch=1.x.x)](http://inch-ci.org/github/beam-community/stripe-elixir?branch=1.x.x) [![Coverage Status](https://coveralls.io/repos/github/beam-community/stripe-elixir/badge.svg?branch=1.x.x)](https://coveralls.io/github/beam-community/stripe-elixir?branch=1.x.x)
 
 # Which version should I use?
 
@@ -20,9 +20,9 @@ The actively developed line of releases is `2.x.x` and is contained within the `
 
 Below is a list of which Stripe API version recent releases of Stripity Stripe use. It only indicates the API version being called, not necessarily its compatibility. See the [Stripe API Upgrades page](https://stripe.com/docs/upgrades) for more details.
 
-Starting with stripity_stripe version 2.5.0, you can specify the Stripe API Version to use for a specific request by including the `:api_version` option. Note that while this will use a specific Stripe API Version to make the request, the library will still expect a response matching its corresponding default Stripe API Version. See the [Shared Options documentation](https://hexdocs.pm/stripity_stripe/2.7.0/Stripe.html#module-shared-options) for more details.
+Starting with stripe_elixir version 2.5.0, you can specify the Stripe API Version to use for a specific request by including the `:api_version` option. Note that while this will use a specific Stripe API Version to make the request, the library will still expect a response matching its corresponding default Stripe API Version. See the [Shared Options documentation](https://hexdocs.pm/stripe_elixir/2.7.0/Stripe.html#module-shared-options) for more details.
 
-| `:stripity_stripe` | Stripe API Version |
+| `:stripe_elixir` | Stripe API Version |
 | ------------------ | ------------------ |
 | `2.0.x`            | `2018-02-28`       |
 | `2.1.0 - 2.2.0`    | `2018-05-21`       |
@@ -33,22 +33,22 @@ Starting with stripity_stripe version 2.5.0, you can specify the Stripe API Vers
 
 # Documentation
 
-- [Latest HexDocs](https://hexdocs.pm/stripity_stripe/)
+- [Latest HexDocs](https://hexdocs.pm/stripe_elixir/)
 
-- [1.x.x](https://hexdocs.pm/stripity_stripe/1.6.1/)
+- [1.x.x](https://hexdocs.pm/stripe_elixir/1.6.1/)
 
 ## Installation
 
 Install the dependency by version:
 
 ```elixir
-{:stripity_stripe, "~> 2.0"}
+{:stripe_elixir, "~> 2.0"}
 ```
 
 Or by commit reference:
 
 ```elixir
-{:stripity_stripe, git: "https://github.com/code-corps/stripity_stripe", ref: "8c091d4278d29a917bacef7bb2f0606317fcc025"}
+{:stripe_elixir, git: "https://github.com/beam-community/stripe-elixir", ref: "8c091d4278d29a917bacef7bb2f0606317fcc025"}
 ```
 
 Next, add to your applications:
@@ -57,7 +57,7 @@ _Not necessary if using elixir >= 1.4_
 
 ```elixir
 defp application do
-  [applications: [:stripity_stripe]]
+  [applications: [:stripe_elixir]]
 end
 ```
 
@@ -68,23 +68,23 @@ To make API calls, it is necessary to configure your Stripe secret key.
 ```elixir
 import Config
 
-config :stripity_stripe, api_key: System.get_env("STRIPE_SECRET")
+config :stripe_elixir, api_key: System.get_env("STRIPE_SECRET")
 # OR
-config :stripity_stripe, api_key: "YOUR SECRET KEY"
+config :stripe_elixir, api_key: "YOUR SECRET KEY"
 ```
 
 It's possible to use a function or a tuple to resolve the secret:
 
 ```elixir
-config :stripity_stripe, api_key: {MyApp.Secrets, :stripe_secret, []}
+config :stripe_elixir, api_key: {MyApp.Secrets, :stripe_secret, []}
 # OR
-config :stripity_stripe, api_key: fn -> System.get_env("STRIPE_SECRET") end
+config :stripe_elixir, api_key: fn -> System.get_env("STRIPE_SECRET") end
 ```
 
 Moreover, if you are using Poison instead of Jason, you can configure the library to use Poison like so:
 
 ```elixir
-config :stripity_stripe, json_library: Poison
+config :stripe_elixir, json_library: Poison
 ```
 
 ### Timeout
@@ -92,7 +92,7 @@ config :stripity_stripe, json_library: Poison
 To set timeouts, pass opts for the http client. The default one is Hackney.
 
 ```elixir
-config :stripity_stripe, hackney_opts: [{:connect_timeout, 1000}, {:recv_timeout, 5000}]
+config :stripe_elixir, hackney_opts: [{:connect_timeout, 1000}, {:recv_timeout, 5000}]
 ```
 
 ### Request Retries
@@ -100,7 +100,7 @@ config :stripity_stripe, hackney_opts: [{:connect_timeout, 1000}, {:recv_timeout
 To set retries, you can pass the number of attempts and range of backoff (time between attempting the request again) in milliseconds.
 
 ```elixir
-config :stripity_stripe, :retries, [max_attempts: 3, base_backoff: 500, max_backoff: 2_000]
+config :stripe_elixir, :retries, [max_attempts: 3, base_backoff: 500, max_backoff: 2_000]
 ```
 
 ## Examples
@@ -174,7 +174,7 @@ Now you can charge the customer using a `PaymentIntent` from [Stripe](https://st
 
 ## Note: Object Expansion
 
-Some Stripe API endpoints support returning related objects via the object expansion query parameter. To take advantage of this feature, stripity_stripe accepts
+Some Stripe API endpoints support returning related objects via the object expansion query parameter. To take advantage of this feature, stripe_elixir accepts
 a list of strings to be passed into `opts` under the `:expand` key indicating which objects should be expanded.
 
 For example, calling `Charge.retrieve("ch_123")` would return a charge without expanding any objects.
@@ -241,7 +241,7 @@ To configure your test environment to use the local stripe-mock server, you may
 need to set the `api_base_url` field in your config:
 
 ```
-config :stripity_stripe,
+config :stripe_elixir,
   api_key: "sk_test_thisisaboguskey",
   api_base_url: "http://localhost:12111/v1/"
 ```
@@ -260,14 +260,14 @@ Works with API version 2015-10-16
 Install the dependency:
 
 ```elixir
-{:stripity_stripe, "~> 1.6"}
+{:stripe_elixir, "~> 1.6"}
 ```
 
 Next, add to your applications:
 
 ```elixir
 defp application do
-  [applications: [:stripity_stripe]]
+  [applications: [:stripe_elixir]]
 end
 ```
 
@@ -278,8 +278,8 @@ To make API calls, it is necessary to configure your Stripe secret key (and opti
 ```elixir
 import Config
 
-config :stripity_stripe, secret_key: "YOUR SECRET KEY"
-config :stripity_stripe, platform_client_id: "YOUR CONNECT PLATFORM CLIENT ID"
+config :stripe_elixir, secret_key: "YOUR SECRET KEY"
+config :stripe_elixir, platform_client_id: "YOUR CONNECT PLATFORM CLIENT ID"
 ```
 
 ## Testing
@@ -335,7 +335,7 @@ Stripe Connect allows you to provide your customers with an easy onboarding to t
 First, you need to register your platform on Stripe Connect to obtain a `client_id`. In your account settings, there's a "Connect" tab, select it. Then fill the information to activate your connect platform settings. The select he `client_id` (notice there's one for dev and one for prod), stash this `client_id` in the config file under
 
 ```elixir
-config :stripity_stripe, platform_client_id: "ac_???"
+config :stripe_elixir, platform_client_id: "ac_???"
 ```
 
 or in an env var named `STRIPE_PLATFORM_CLIENT_ID`.
@@ -422,4 +422,4 @@ As I began digging things up with these other libraries it became rather apparen
 
 ## Update
 
-As of October 18th, Rob has graciously handed over the reins to the teams at [Code Corps](https://www.codecorps.org/) and [Strumber](https://strumber.com/). To address the concerns Rob mentioned above and update the high level api to work with all of the Stripe API Endpoints, they have since worked to release stripity_stripe 2.0, which is now the actively developed line of releases.
+As of October 18th, Rob has graciously handed over the reins to the teams at [Code Corps](https://www.codecorps.org/) and [Strumber](https://strumber.com/). To address the concerns Rob mentioned above and update the high level api to work with all of the Stripe API Endpoints, they have since worked to release stripe_elixir 2.0, which is now the actively developed line of releases.

--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -9,13 +9,13 @@ defmodule Stripe do
   You need to set your API key in your application configuration. Typically
   this is done in `config/config.exs` or a similar file. For example:
 
-      config :stripity_stripe, api_key: "sk_test_abc123456789qwerty"
+      config :stripe_elixir, api_key: "sk_test_abc123456789qwerty"
 
   You can also utilize `System.get_env/1` to retrieve the API key from
   an environment variable, but remember that this can cause issues if
   you use a release tool like exrm or Distillery.
 
-      config :stripity_stripe, api_key: System.get_env("STRIPE_API_KEY")
+      config :stripe_elixir, api_key: System.get_env("STRIPE_API_KEY")
 
   ### Shared Options
 
@@ -52,14 +52,14 @@ defmodule Stripe do
   Both these settings are located under the `:pool_options` key in
   your application configuration:
 
-      config :stripity_stripe, :pool_options,
+      config :stripe_elixir, :pool_options,
         timeout: 5_000,
         max_connections: 10
 
   If you prefer, you can also turn pooling off completely using
   the `:use_connection_pool` setting:
 
-      config :stripity_stripe, use_connection_pool: false
+      config :stripe_elixir, use_connection_pool: false
 
   """
   use Application

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -26,7 +26,7 @@ defmodule Stripe.API do
 
   @doc """
   In config.exs your implicit or explicit configuration is:
-    config :stripity_stripe,
+    config :stripe_elixir,
       json_library: Poison # defaults to Jason but can be configured to Poison
   """
   @spec json_library() :: module
@@ -431,7 +431,7 @@ defmodule Stripe.API do
   @spec retry_response?(http_success | http_failure) :: boolean
   # 409 conflict
   defp retry_response?({:error, 409, _headers, _body}), do: true
-  # https://github.com/beam-community/stripity_stripe/issues/686
+  # https://github.com/beam-community/stripe_elixir/issues/686
   defp retry_response?({:error, 429, _headers, _body}), do: true
   # Destination refused the connection, the connection was reset, or a
   # variety of other connection failures. This could occur from a single

--- a/lib/stripe/config.ex
+++ b/lib/stripe/config.ex
@@ -12,7 +12,7 @@ defmodule Stripe.Config do
   def resolve(key, default \\ nil)
 
   def resolve(key, default) when is_atom(key) do
-    Application.get_env(:stripity_stripe, key, default)
+    Application.get_env(:stripe_elixir, key, default)
     |> expand_value()
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,12 +1,12 @@
 defmodule Stripe.Mixfile do
   use Mix.Project
 
-  @source_url "https://github.com/code-corps/stripity_stripe"
+  @source_url "https://github.com/beam-community/stripe-elixir"
   @version "2.17.2"
 
   def project do
     [
-      app: :stripity_stripe,
+      app: :stripe_elixir,
       version: @version,
       elixir: "~> 1.10",
       deps: deps(),
@@ -21,7 +21,7 @@ defmodule Stripe.Mixfile do
       ],
       dialyzer: [
         plt_add_apps: [:mix],
-        plt_file: {:no_warn, "priv/plts/stripity_stripe.plt"}
+        plt_file: {:no_warn, "priv/plts/stripe_elixir.plt"}
       ],
       test_coverage: [tool: ExCoveralls]
     ]

--- a/test/stripe/api_test.exs
+++ b/test/stripe/api_test.exs
@@ -109,7 +109,7 @@ defmodule Stripe.APITest do
       end
     end
 
-    Application.put_env(:stripity_stripe, :http_module, HackneyMock)
+    Application.put_env(:stripe_elixir, :http_module, HackneyMock)
 
     {:ok, body} = Stripe.API.oauth_request(:post, "deauthorize", %{})
     assert body["Authorization"] == "Bearer sk_test_123"
@@ -141,13 +141,13 @@ defmodule Stripe.APITest do
       end
     end
 
-    Application.put_env(:stripity_stripe, :http_module, HackneyMock)
+    Application.put_env(:stripe_elixir, :http_module, HackneyMock)
 
     {:ok, request_opts} = Stripe.API.request(%{}, :get, "/", %{}, [])
     refute Map.has_key?(request_opts, "connect_timeout")
     refute Map.has_key?(request_opts, "recv_timeout")
 
-    Application.put_env(:stripity_stripe, :hackney_opts, [
+    Application.put_env(:stripe_elixir, :hackney_opts, [
       {:connect_timeout, 1000},
       {:recv_timeout, 5000}
     ])

--- a/test/stripe/config_test.exs
+++ b/test/stripe/config_test.exs
@@ -8,18 +8,18 @@ defmodule Stripe.ConfigTest do
   end
 
   test "returns the requested configuration value" do
-    Application.put_env(:stripity_stripe, :__test, "test-test")
+    Application.put_env(:stripe_elixir, :__test, "test-test")
     assert(Stripe.Config.resolve(:__test) == "test-test")
   end
 
   test "evaluates functions" do
-    Application.put_env(:stripity_stripe, :__test, fn -> "test-test" end)
+    Application.put_env(:stripe_elixir, :__test, fn -> "test-test" end)
     assert(Stripe.Config.resolve(:__test) == "test-test")
   end
 
   test "applies tuples" do
     Application.put_env(
-      :stripity_stripe,
+      :stripe_elixir,
       :__test,
       {ValueExpansionTestModule, :value, []}
     )
@@ -29,7 +29,7 @@ defmodule Stripe.ConfigTest do
 
   test "if no value exists for the given key it uses the default value" do
     Application.put_env(
-      :stripity_stripe,
+      :stripe_elixir,
       :__test,
       {ValueExpansionTestModule, :value, []}
     )
@@ -39,7 +39,7 @@ defmodule Stripe.ConfigTest do
 
   test "raises if the key isn't an atom" do
     Application.put_env(
-      :stripity_stripe,
+      :stripe_elixir,
       :__test,
       {ValueExpansionTestModule, :value, []}
     )

--- a/test/support/stripe_case.ex
+++ b/test/support/stripe_case.ex
@@ -26,7 +26,7 @@ defmodule Stripe.StripeCase do
   end
 
   def stripe_base_url() do
-    Application.get_env(:stripity_stripe, :api_base_url)
+    Application.get_env(:stripe_elixir, :api_base_url)
   end
 
   defp assert_stripe_request_headers(nil, _), do: nil
@@ -82,7 +82,7 @@ defmodule Stripe.StripeCase do
           stripe_base_url: 0
         ]
 
-      Application.put_env(:stripity_stripe, :http_module, HackneyMock)
+      Application.put_env(:stripe_elixir, :http_module, HackneyMock)
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -13,10 +13,10 @@ end
 api_base_url = System.get_env("STRIPE_API_BASE_URL") || "http://localhost:12111/v1/"
 api_upload_url = System.get_env("STRIPE_API_UPLOAD_URL") || "http://localhost:12112/v1/"
 
-Application.put_env(:stripity_stripe, :api_base_url, api_base_url)
-Application.put_env(:stripity_stripe, :api_upload_url, api_upload_url)
-Application.put_env(:stripity_stripe, :api_key, "sk_test_123")
-Application.put_env(:stripity_stripe, :log_level, :debug)
+Application.put_env(:stripe_elixir, :api_base_url, api_base_url)
+Application.put_env(:stripe_elixir, :api_upload_url, api_upload_url)
+Application.put_env(:stripe_elixir, :api_key, "sk_test_123")
+Application.put_env(:stripe_elixir, :log_level, :debug)
 
 Mox.defmock(Stripe.Connect.OAuthMock, for: Stripe.Connect.OAuth)
 Mox.defmock(Stripe.APIMock, for: Stripe.API)


### PR DESCRIPTION
This PR updates references that were named stripity-stripe.  Now aptly named stripe-elixir.